### PR TITLE
Minor fix in tests to get GlobalConfig rather than Future

### DIFF
--- a/e2e_test/test/e2e_test.dart
+++ b/e2e_test/test/e2e_test.dart
@@ -10,7 +10,7 @@ _mockFileFactory(String path) => new MockFile(path);
 
 main() {
   test('can generate wrappers', () async {
-    var config = parseArgs(['behavior_config.yaml'], '');
+    var config = await parseArgs(['behavior_config.yaml'], '');
     await generateWrappers(config, createFile: _mockFileFactory);
     expectFilesCreated('example_behavior');
     expectFilesCreated('example_element');


### PR DESCRIPTION
This should allow the tests to pass.  Not much of a change, but if you could include this in your pull request against the dart-lang/custom-element-apigen, it might help things.  I need this package to work.